### PR TITLE
Fixed non-visibility of default dictionary.

### DIFF
--- a/xkcdpass.py
+++ b/xkcdpass.py
@@ -19,8 +19,9 @@ usage = "xkcdpass.py [-h|--help] [-l|--length=<length>] [-d|--dictionary=<path>]
 
 parser = OptionParser(usage=usage)
 
+default_dictionary = os.path.join(os.path.dirname(__file__), 'dictionary')
 parser.add_option("-d", "--dictionary", dest="dictionary_path",
-                  help="Specify a path to a dictionary", metavar="PATH", default="dictionary")
+                  help="Specify a path to a dictionary", metavar="PATH", default=default_dictionary)
 
 parser.add_option("-l", "--length", dest="password_length", type="int",
                   help="Specify the password length", metavar="LENGTH", default=4)


### PR DESCRIPTION
Default dictionary only worked if current working directory was actually
that of the script. This fix sets the default to the dictionary's
absolute path.

I tested and found this problem in both Windows 8.1 and Linux Mint w/MATE 16.
